### PR TITLE
Fix bugs in activity.py return types and test collection warning

### DIFF
--- a/fitbit_client/resources/activity.py
+++ b/fitbit_client/resources/activity.py
@@ -281,7 +281,7 @@ class ActivityResource(BaseResource):
 
     def create_favorite_activity(
         self, activity_id: int, user_id: str = "-", debug: bool = False
-    ) -> Dict[Never, Never]:
+    ) -> None:
         """Adds an activity to the user's list of favorite activities.
 
         Favorite activities appear in a special section of the Fitbit app and website,
@@ -295,7 +295,7 @@ class ActivityResource(BaseResource):
             debug: If True, prints a curl command to stdout to help with debugging (default: False)
 
         Returns:
-            Dict[Never, Never]: Empty dictionary on success, with HTTP 201 status code
+            None: Returns None on success, with HTTP 201 status code
 
         Raises:
             fitbit_client.exceptions.InvalidRequestException: If activity_id is invalid
@@ -314,11 +314,11 @@ class ActivityResource(BaseResource):
             http_method="POST",
             debug=debug,
         )
-        return cast(Dict[Never, Never], result)
+        return cast(None, result)
 
     def delete_activity_log(
         self, activity_log_id: int, user_id: str = "-", debug: bool = False
-    ) -> Dict[Never, Never]:
+    ) -> None:
         """Deletes a specific activity log entry from the user's activity history.
 
         This endpoint permanently removes an activity from the user's activity history.
@@ -333,7 +333,7 @@ class ActivityResource(BaseResource):
             debug: If True, prints a curl command to stdout to help with debugging (default: False)
 
         Returns:
-            Dict[Never, Never]: Empty dictionary on success, with HTTP 204 status code
+            None: Returns None on success, with HTTP 204 status code
 
         Raises:
             fitbit_client.exceptions.InvalidRequestException: If activity_log_id is invalid
@@ -351,7 +351,7 @@ class ActivityResource(BaseResource):
         result = self._make_request(
             f"activities/{activity_log_id}.json", user_id=user_id, http_method="DELETE", debug=debug
         )
-        return cast(Dict[Never, Never], result)
+        return cast(None, result)
 
     def delete_favorite_activity(
         self, activity_id: int, user_id: str = "-", debug: bool = False

--- a/tests/utils/test_curl_debug_mixin.py
+++ b/tests/utils/test_curl_debug_mixin.py
@@ -14,27 +14,31 @@ from fitbit_client.utils.curl_debug_mixin import CurlDebugMixin
 
 
 # Create a test class that uses the mixin for debug testing
-class TestResource(CurlDebugMixin):
-    """Test class that uses CurlDebugMixin"""
+# Using a function to create the test class to avoid pytest collection warning
+def create_test_resource_class():
+    class TestResource(CurlDebugMixin):
+        """Test class that uses CurlDebugMixin"""
 
-    def __init__(self):
-        self.oauth = Mock()
-        self.oauth.token = {"access_token": "test_token"}
+        def __init__(self):
+            self.oauth = Mock()
+            self.oauth.token = {"access_token": "test_token"}
 
-    def make_debug_request(self, debug=False):
-        """Test method that simulates _make_request with debug mode"""
-        url = "https://api.fitbit.com/1/user/-/test/endpoint"
+        def make_debug_request(self, debug=False):
+            """Test method that simulates _make_request with debug mode"""
+            url = "https://api.fitbit.com/1/user/-/test/endpoint"
 
-        if debug:
-            curl_command = self._build_curl_command(
-                url=url, http_method="GET", params={"param1": "value1"}
-            )
-            print(f"\n# Debug curl command:")
-            print(curl_command)
-            print()
-            return None
+            if debug:
+                curl_command = self._build_curl_command(
+                    url=url, http_method="GET", params={"param1": "value1"}
+                )
+                print(f"\n# Debug curl command:")
+                print(curl_command)
+                print()
+                return None
 
-        return {"success": True}
+            return {"success": True}
+
+    return TestResource
 
 
 @fixture
@@ -101,7 +105,8 @@ def test_build_curl_command_with_delete(curl_debug_mixin):
 
 def test_debug_mode_integration(capsys):
     """Test debug mode integration with a resource class"""
-    # Create test resource
+    # Create test resource class and instance
+    TestResource = create_test_resource_class()
     resource = TestResource()
 
     # Call make_debug_request with debug=True


### PR DESCRIPTION
- Change Dict[Never, Never] return types to None for create_favorite_activity and delete_activity_log
- Fix pytest collection warning by refactoring TestResource to be created by a factory function