### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/fitbit_client/resources/_base.py
+++ b/fitbit_client/resources/_base.py
@@ -1,5 +1,6 @@
 # fitbit_client/resources/_base.py
 
+
 # Standard library imports
 from datetime import datetime
 from inspect import currentframe
@@ -14,6 +15,7 @@ from typing import cast
 
 # Third party imports
 from requests import Response
+import re
 from requests_oauthlib import OAuth2Session
 
 # Local imports
@@ -516,8 +518,9 @@ class BaseResource(CurlDebugMixin):
 
         if debug:
             curl_command = self._build_curl_command(url, http_method, data, json, params)
+            sanitized_curl_command = self._sanitize_curl_command(curl_command)
             print(f"\n# Debug curl command for {calling_method}:")
-            print(curl_command)
+            print(sanitized_curl_command)
             print()
             return None
 


### PR DESCRIPTION
Potential fix for [https://github.com/jpstroop/fitbit-client-python/security/code-scanning/8](https://github.com/jpstroop/fitbit-client-python/security/code-scanning/8)

To fix the problem, we should avoid printing sensitive information directly to the console. Instead, we can sanitize the `curl_command` by removing or masking sensitive data before printing it. This way, developers can still use the debug mode for troubleshooting without exposing sensitive information.

- Identify the parts of the `curl_command` that contain sensitive information.
- Replace or mask these parts before printing the `curl_command`.
- Ensure that the changes are made in the `_make_request` method in the `fitbit_client/resources/_base.py` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
